### PR TITLE
Fix audio port tracking crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ EQVita is a hobby homebrew project made to give the Vita a richer sound. It ship
 Install it, open the app, pick a preset, and make the Vita sound less flat.
 Nerd version: the plugin hooks `sceAudioOutOutput`, while the app handles presets, route hints, themes, logs, and boot state.
 
-Current app/plugin ABI: `1.13.0`.
+Current app/plugin ABI: `1.14.0`.
 
 Questions, setup help, preset sharing, and random EQVita ideas live in [Discussions](https://github.com/shev0k/EQVita/discussions). Issues are better for actual bugs with logs and steps.
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,7 +7,7 @@ set(A_SELF eboot.bin)
 
 set(VITA_APP_NAME "EQ Vita")
 set(VITA_TITLEID "EQSP00001")
-set(VITA_VERSION "01.13")
+set(VITA_VERSION "01.14")
 
 add_executable("${A_NAME}"
   main.c

--- a/common/eq_shared.h
+++ b/common/eq_shared.h
@@ -5,7 +5,7 @@
 #include <string.h>
 
 #define EQ_VERSION_MAJOR 1
-#define EQ_VERSION_MINOR 13
+#define EQ_VERSION_MINOR 14
 #define EQ_VERSION_PATCH 0
 
 #define EQ_BANDS 10
@@ -19,6 +19,7 @@
 #define EQ_LEGACY_ABI_VERSION_1_10 EQ_VERSION_PACK(1, 10)
 #define EQ_LEGACY_ABI_VERSION_1_11 EQ_VERSION_PACK(1, 11)
 #define EQ_LEGACY_ABI_VERSION_1_12 EQ_VERSION_PACK(1, 12)
+#define EQ_LEGACY_ABI_VERSION_1_13 EQ_VERSION_PACK(1, 13)
 
 #define EQ_PRESET_MAGIC 0x50565145u /* EQVP */
 #define EQ_PRESET_VERSION 2u
@@ -399,7 +400,8 @@ static inline int eq_control_is_compatible(const eq_control_t *ctrl)
 
     if (ctrl->version == EQ_LEGACY_ABI_VERSION_1_10 ||
         ctrl->version == EQ_LEGACY_ABI_VERSION_1_11 ||
-        ctrl->version == EQ_LEGACY_ABI_VERSION_1_12) {
+        ctrl->version == EQ_LEGACY_ABI_VERSION_1_12 ||
+        ctrl->version == EQ_LEGACY_ABI_VERSION_1_13) {
         if (ctrl->size == sizeof(eq_control_t) || ctrl->size == sizeof(eq_shared_block_t)) {
             return 1;
         }

--- a/plugin/exports.yml
+++ b/plugin/exports.yml
@@ -2,7 +2,7 @@ EQSpeaker:
   attributes: 0
   version:
     major: 1
-    minor: 13
+    minor: 14
   main:
     start: module_start
     stop: module_stop

--- a/plugin/main.c
+++ b/plugin/main.c
@@ -2,6 +2,7 @@
 #include <psp2kern/kernel/sysmem.h>
 #include <psp2kern/kernel/cpu.h>
 #include <psp2kern/kernel/threadmgr.h>
+#include <psp2kern/kernel/threadmgr/misc.h>
 #include <psp2kern/ctrl.h>
 #include <taihen.h>
 #include <psp2/audioout.h>
@@ -117,6 +118,14 @@ static int hook_enter(void) {
 
 static void hook_leave(void) {
     __sync_sub_and_fetch(&g_active_callbacks, 1);
+}
+
+static uint32_t current_audio_owner_id(void) {
+    SceUID pid = ksceKernelGetProcessId();
+    if (pid < 0) {
+        return 0;
+    }
+    return (uint32_t)pid;
 }
 
 static void publish_control_locked(const eq_control_t *control) {
@@ -539,6 +548,7 @@ static void update_status(uint32_t sample_rate, eq_route_t route, int eq_active,
 }
 
 static int recover_port_config_after_output(int port) {
+    uint32_t owner_id = current_audio_owner_id();
     int len;
     int freq;
     int mode;
@@ -559,7 +569,7 @@ static int recover_port_config_after_output(int port) {
     if (try_lock_audio() < 0) {
         return -1;
     }
-    res = eq_audio_port_registry_recover_config(&g_ports, port, 0, (uint32_t)len, (uint32_t)freq, mode) ? 0 : -1;
+    res = eq_audio_port_registry_recover_config_owned(&g_ports, owner_id, port, eq_audio_port_type_for_recovered_id(port), (uint32_t)len, (uint32_t)freq, mode) ? 0 : -1;
     unlock_audio();
     return res;
 }
@@ -607,6 +617,7 @@ static int sceAudioOutOutput_hook(int port, const void *buf) {
     eq_control_t control;
     eq_audio_tracked_port_t *processing_port = NULL;
     eq_audio_port_config_t processing_config;
+    uint32_t owner_id = 0;
 #if EQVITA_AUDIO_DIAGNOSTICS
     eq_diag_port_meta_t diag_port_meta;
 #endif
@@ -636,6 +647,7 @@ static int sceAudioOutOutput_hook(int port, const void *buf) {
     }
 
     start_us = ksceKernelGetSystemTimeLow();
+    owner_id = current_audio_owner_id();
 
     memset(&control, 0, sizeof(control));
 #if EQVITA_AUDIO_DIAGNOSTICS
@@ -660,7 +672,7 @@ static int sceAudioOutOutput_hook(int port, const void *buf) {
         }
 
         eq_audio_port_registry_drain_completed(&g_ports);
-        p = eq_audio_port_registry_find(&g_ports, port);
+        p = eq_audio_port_registry_find_owned(&g_ports, owner_id, port);
         if (!p) {
             recover_after_output = 1;
         }
@@ -674,7 +686,7 @@ static int sceAudioOutOutput_hook(int port, const void *buf) {
             channels = p->config.channels;
             reason = EQ_BYPASS_AUDIO_BUSY;
         } else if (p && p->config.in_use) {
-            processing_port = eq_audio_port_registry_begin_processing(&g_ports, port);
+            processing_port = eq_audio_port_registry_begin_processing_owned(&g_ports, owner_id, port);
             if (processing_port) {
                 processing_config = processing_port->config;
 #if EQVITA_AUDIO_DIAGNOSTICS
@@ -935,16 +947,18 @@ static int sceAudioOutOpenPort_hook(int type, int len, int freq, int mode) {
     uint32_t generation = 0;
     uint32_t dirty_counter = 0;
     uint32_t channels = 0;
+    uint32_t owner_id = 0;
     if (!hook_enter()) {
         int port = TAI_CONTINUE(int, g_hook_open, type, len, freq, mode);
         hook_leave();
         return port;
     }
+    owner_id = current_audio_owner_id();
     int port = TAI_CONTINUE(int, g_hook_open, type, len, freq, mode);
     channels = (uint32_t)(eq_audio_mode_to_channels(mode) > 0 ? eq_audio_mode_to_channels(mode) : 0);
     if (g_processing_enabled && port >= 0) {
         if (lock_audio() >= 0) {
-            eq_audio_tracked_port_t *tracked = eq_audio_port_registry_open(&g_ports, port, (uint32_t)type, (uint32_t)len, (uint32_t)freq, mode);
+            eq_audio_tracked_port_t *tracked = eq_audio_port_registry_open_owned(&g_ports, owner_id, port, (uint32_t)type, (uint32_t)len, (uint32_t)freq, mode);
             if (tracked) {
                 generation = tracked->generation;
                 dirty_counter = tracked->last_dirty;
@@ -965,18 +979,20 @@ static int sceAudioOutSetConfig_hook(int port, SceSize len, int freq, int mode) 
     uint32_t final_len = (len == (SceSize)-1) ? 0 : (uint32_t)len;
     uint32_t final_freq = (freq < 0) ? 0 : (uint32_t)freq;
     uint32_t final_channels = (mode < 0 || eq_audio_mode_to_channels(mode) < 0) ? 0 : (uint32_t)eq_audio_mode_to_channels(mode);
+    uint32_t owner_id = 0;
     if (!hook_enter()) {
         int res = TAI_CONTINUE(int, g_hook_set_config, port, len, freq, mode);
         hook_leave();
         return res;
     }
+    owner_id = current_audio_owner_id();
     int res = TAI_CONTINUE(int, g_hook_set_config, port, len, freq, mode);
     if (g_processing_enabled && port >= 0 && res >= 0) {
         if (lock_audio() >= 0) {
             uint32_t len_arg = (len == (SceSize)-1) ? EQ_AUDIO_KEEP_U32 : (uint32_t)len;
-            (void)eq_audio_port_registry_set_config(&g_ports, port, len_arg, freq, mode);
+            (void)eq_audio_port_registry_set_config_owned(&g_ports, owner_id, port, len_arg, freq, mode);
             {
-                eq_audio_tracked_port_t *tracked = eq_audio_port_registry_find(&g_ports, port);
+                eq_audio_tracked_port_t *tracked = eq_audio_port_registry_find_owned(&g_ports, owner_id, port);
                 if (tracked) {
                     generation = tracked->generation;
                     port_type = tracked->config.type;
@@ -1002,15 +1018,17 @@ static int sceAudioOutReleasePort_hook(int port) {
     uint32_t len = 0;
     uint32_t freq = 0;
     uint32_t channels = 0;
+    uint32_t owner_id = 0;
     if (!hook_enter()) {
         int res = TAI_CONTINUE(int, g_hook_release, port);
         hook_leave();
         return res;
     }
+    owner_id = current_audio_owner_id();
     int res = TAI_CONTINUE(int, g_hook_release, port);
     if (g_processing_enabled && port >= 0 && res >= 0) {
         if (lock_audio() >= 0) {
-            eq_audio_tracked_port_t *tracked = eq_audio_port_registry_find(&g_ports, port);
+            eq_audio_tracked_port_t *tracked = eq_audio_port_registry_find_owned(&g_ports, owner_id, port);
             if (tracked) {
                 generation = tracked->generation;
                 port_type = tracked->config.type;
@@ -1019,7 +1037,7 @@ static int sceAudioOutReleasePort_hook(int port) {
                 freq = tracked->config.freq;
                 channels = tracked->config.channels;
             }
-            (void)eq_audio_port_registry_release(&g_ports, port);
+            (void)eq_audio_port_registry_release_owned(&g_ports, owner_id, port);
             unlock_audio();
         }
         diag_emit_lifecycle_now(EQ_DIAG_EVENT_PORT_RELEASE, port, generation, port_type,

--- a/plugin/port_registry.h
+++ b/plugin/port_registry.h
@@ -6,12 +6,13 @@
 #include "dsp.h"
 #include "port_state.h"
 
-#define EQ_AUDIO_MAX_TRACKED_PORTS 8
+#define EQ_AUDIO_MAX_TRACKED_PORTS 16
 #define EQ_AUDIO_PORT_ID_UNUSED (-1)
 #define EQ_AUDIO_SCRATCH_MAX_FRAMES 4096
 
 typedef struct eq_audio_tracked_port
 {
+    uint32_t owner_id;
     int port_id;
     eq_audio_port_config_t config;
     eq_dsp_state_t dsp;
@@ -127,14 +128,19 @@ static inline uint32_t eq_audio_port_registry_take_generation(eq_audio_port_regi
     return generation;
 }
 
-static inline eq_audio_tracked_port_t *eq_audio_port_registry_find(eq_audio_port_registry_t *registry, int port_id)
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_find_owned(eq_audio_port_registry_t *registry,
+                                                                         uint32_t owner_id,
+                                                                         int port_id)
 {
     if (!registry) {
         return NULL;
     }
 
     for (int i = 0; i < EQ_AUDIO_MAX_TRACKED_PORTS; ++i) {
-        if (registry->slots[i].port_id == port_id && registry->slots[i].config.in_use && !registry->slots[i].release_pending) {
+        if (registry->slots[i].owner_id == owner_id &&
+            registry->slots[i].port_id == port_id &&
+            registry->slots[i].config.in_use &&
+            !registry->slots[i].release_pending) {
             return &registry->slots[i];
         }
     }
@@ -142,10 +148,17 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_find(eq_audio_port
     return NULL;
 }
 
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_find(eq_audio_port_registry_t *registry, int port_id)
+{
+    return eq_audio_port_registry_find_owned(registry, 0u, port_id);
+}
+
 static inline void eq_audio_port_registry_end_processing(eq_audio_tracked_port_t *slot);
 static inline void eq_audio_port_registry_drain_completed(eq_audio_port_registry_t *registry);
 
-static inline eq_audio_tracked_port_t *eq_audio_port_registry_alloc(eq_audio_port_registry_t *registry, int port_id)
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_alloc_owned(eq_audio_port_registry_t *registry,
+                                                                          uint32_t owner_id,
+                                                                          int port_id)
 {
     eq_audio_tracked_port_t *processing_match = NULL;
 
@@ -155,7 +168,10 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_alloc(eq_audio_por
 
     for (int i = 0; i < EQ_AUDIO_MAX_TRACKED_PORTS; ++i) {
         eq_audio_tracked_port_t *slot = &registry->slots[i];
-        if (slot->port_id == port_id && slot->config.in_use && !slot->release_pending) {
+        if (slot->owner_id == owner_id &&
+            slot->port_id == port_id &&
+            slot->config.in_use &&
+            !slot->release_pending) {
             if (slot->processing) {
                 processing_match = slot;
                 break;
@@ -170,12 +186,18 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_alloc(eq_audio_por
                 processing_match->release_pending = 1;
             }
             eq_audio_tracked_port_reset(&registry->slots[i]);
+            registry->slots[i].owner_id = owner_id;
             registry->slots[i].port_id = port_id;
             return &registry->slots[i];
         }
     }
 
     return NULL;
+}
+
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_alloc(eq_audio_port_registry_t *registry, int port_id)
+{
+    return eq_audio_port_registry_alloc_owned(registry, 0u, port_id);
 }
 
 static inline void eq_audio_tracked_port_apply_config(eq_audio_tracked_port_t *slot,
@@ -203,12 +225,13 @@ static inline void eq_audio_tracked_port_apply_config(eq_audio_tracked_port_t *s
     }
 }
 
-static inline eq_audio_tracked_port_t *eq_audio_port_registry_open(eq_audio_port_registry_t *registry,
-                                                                   int port_id,
-                                                                   uint32_t type,
-                                                                   uint32_t len,
-                                                                   uint32_t freq,
-                                                                   int mode)
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_open_owned(eq_audio_port_registry_t *registry,
+                                                                         uint32_t owner_id,
+                                                                         int port_id,
+                                                                         uint32_t type,
+                                                                         uint32_t len,
+                                                                         uint32_t freq,
+                                                                         int mode)
 {
     eq_audio_tracked_port_t *slot;
     eq_audio_port_config_t config;
@@ -220,13 +243,14 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_open(eq_audio_port
     }
 
     eq_audio_port_registry_drain_completed(registry);
-    slot = eq_audio_port_registry_alloc(registry, port_id);
+    slot = eq_audio_port_registry_alloc_owned(registry, owner_id, port_id);
     if (!slot) {
         return NULL;
     }
 
     generation = eq_audio_port_registry_take_generation(registry);
     eq_audio_tracked_port_reset(slot);
+    slot->owner_id = owner_id;
     slot->port_id = port_id;
     slot->generation = generation;
     slot->config = config;
@@ -236,17 +260,28 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_open(eq_audio_port
     return slot;
 }
 
-static inline int eq_audio_port_registry_set_config(eq_audio_port_registry_t *registry,
-                                                    int port_id,
-                                                    uint32_t len,
-                                                    int freq,
-                                                    int mode)
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_open(eq_audio_port_registry_t *registry,
+                                                                   int port_id,
+                                                                   uint32_t type,
+                                                                   uint32_t len,
+                                                                   uint32_t freq,
+                                                                   int mode)
 {
-    eq_audio_tracked_port_t *slot = eq_audio_port_registry_find(registry, port_id);
+    return eq_audio_port_registry_open_owned(registry, 0u, port_id, type, len, freq, mode);
+}
+
+static inline int eq_audio_port_registry_set_config_owned(eq_audio_port_registry_t *registry,
+                                                          uint32_t owner_id,
+                                                          int port_id,
+                                                          uint32_t len,
+                                                          int freq,
+                                                          int mode)
+{
+    eq_audio_tracked_port_t *slot;
     eq_audio_port_config_t next_config;
 
     eq_audio_port_registry_drain_completed(registry);
-    slot = eq_audio_port_registry_find(registry, port_id);
+    slot = eq_audio_port_registry_find_owned(registry, owner_id, port_id);
     if (!slot) {
         return -1;
     }
@@ -271,12 +306,22 @@ static inline int eq_audio_port_registry_set_config(eq_audio_port_registry_t *re
     return 0;
 }
 
-static inline eq_audio_tracked_port_t *eq_audio_port_registry_recover_config(eq_audio_port_registry_t *registry,
-                                                                             int port_id,
-                                                                             uint32_t type,
-                                                                             uint32_t len,
-                                                                             uint32_t freq,
-                                                                             int mode)
+static inline int eq_audio_port_registry_set_config(eq_audio_port_registry_t *registry,
+                                                    int port_id,
+                                                    uint32_t len,
+                                                    int freq,
+                                                    int mode)
+{
+    return eq_audio_port_registry_set_config_owned(registry, 0u, port_id, len, freq, mode);
+}
+
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_recover_config_owned(eq_audio_port_registry_t *registry,
+                                                                                   uint32_t owner_id,
+                                                                                   int port_id,
+                                                                                   uint32_t type,
+                                                                                   uint32_t len,
+                                                                                   uint32_t freq,
+                                                                                   int mode)
 {
     eq_audio_tracked_port_t *slot;
     eq_audio_port_config_t next_config;
@@ -286,9 +331,9 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_recover_config(eq_
     }
 
     eq_audio_port_registry_drain_completed(registry);
-    slot = eq_audio_port_registry_find(registry, port_id);
+    slot = eq_audio_port_registry_find_owned(registry, owner_id, port_id);
     if (!slot) {
-        return eq_audio_port_registry_open(registry, port_id, type, len, freq, mode);
+        return eq_audio_port_registry_open_owned(registry, owner_id, port_id, type, len, freq, mode);
     }
 
     next_config = slot->config;
@@ -306,12 +351,24 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_recover_config(eq_
     return slot;
 }
 
-static inline int eq_audio_port_registry_release(eq_audio_port_registry_t *registry, int port_id)
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_recover_config(eq_audio_port_registry_t *registry,
+                                                                             int port_id,
+                                                                             uint32_t type,
+                                                                             uint32_t len,
+                                                                             uint32_t freq,
+                                                                             int mode)
+{
+    return eq_audio_port_registry_recover_config_owned(registry, 0u, port_id, type, len, freq, mode);
+}
+
+static inline int eq_audio_port_registry_release_owned(eq_audio_port_registry_t *registry,
+                                                       uint32_t owner_id,
+                                                       int port_id)
 {
     eq_audio_tracked_port_t *slot;
 
     eq_audio_port_registry_drain_completed(registry);
-    slot = eq_audio_port_registry_find(registry, port_id);
+    slot = eq_audio_port_registry_find_owned(registry, owner_id, port_id);
     if (!slot) {
         return -1;
     }
@@ -325,12 +382,19 @@ static inline int eq_audio_port_registry_release(eq_audio_port_registry_t *regis
     return 0;
 }
 
-static inline eq_audio_tracked_port_t *eq_audio_port_registry_begin_processing(eq_audio_port_registry_t *registry, int port_id)
+static inline int eq_audio_port_registry_release(eq_audio_port_registry_t *registry, int port_id)
+{
+    return eq_audio_port_registry_release_owned(registry, 0u, port_id);
+}
+
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_begin_processing_owned(eq_audio_port_registry_t *registry,
+                                                                                    uint32_t owner_id,
+                                                                                    int port_id)
 {
     eq_audio_tracked_port_t *slot;
 
     eq_audio_port_registry_drain_completed(registry);
-    slot = eq_audio_port_registry_find(registry, port_id);
+    slot = eq_audio_port_registry_find_owned(registry, owner_id, port_id);
     if (!slot || slot->processing) {
         return NULL;
     }
@@ -338,6 +402,11 @@ static inline eq_audio_tracked_port_t *eq_audio_port_registry_begin_processing(e
     slot->processing = 1;
     slot->processing_complete = 0;
     return slot;
+}
+
+static inline eq_audio_tracked_port_t *eq_audio_port_registry_begin_processing(eq_audio_port_registry_t *registry, int port_id)
+{
+    return eq_audio_port_registry_begin_processing_owned(registry, 0u, port_id);
 }
 
 static inline void eq_audio_port_registry_mark_processing_complete(eq_audio_tracked_port_t *slot)

--- a/plugin/port_state.h
+++ b/plugin/port_state.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 
 #define EQ_AUDIO_KEEP_U32 UINT32_MAX
+#define EQ_AUDIO_PORT_TYPE_MAIN 0u
+#define EQ_AUDIO_PORT_TYPE_BGM 1u
+#define EQ_AUDIO_PORT_TYPE_VOICE 2u
+#define EQ_AUDIO_BGM_PORT_ID 256
 #define EQ_AUDIO_MODE_MONO 0
 #define EQ_AUDIO_MODE_STEREO 1
 #define EQ_AUDIO_MIN_LEN 64u
@@ -28,6 +32,14 @@ static inline int eq_audio_mode_to_channels(int mode)
         return 2;
     }
     return -1;
+}
+
+static inline uint32_t eq_audio_port_type_for_recovered_id(int port_id)
+{
+    if (port_id == EQ_AUDIO_BGM_PORT_ID) {
+        return EQ_AUDIO_PORT_TYPE_BGM;
+    }
+    return EQ_AUDIO_PORT_TYPE_MAIN;
 }
 
 static inline int eq_audio_freq_supported(uint32_t freq)

--- a/tests/test_eq_shared.c
+++ b/tests/test_eq_shared.c
@@ -47,6 +47,13 @@ static void test_defaults_are_compatible_and_safe(void) {
     ASSERT_TRUE(eq_control_is_compatible(&ctrl));
 }
 
+static void test_current_branch_uses_1_14_abi(void) {
+    ASSERT_EQ_U32(EQ_VERSION_MAJOR, 1);
+    ASSERT_EQ_U32(EQ_VERSION_MINOR, 14);
+    ASSERT_EQ_U32(EQ_VERSION_PATCH, 0);
+    ASSERT_EQ_U32(EQ_ABI_VERSION, EQ_VERSION_PACK(1, 14));
+}
+
 static void test_validation_rejects_wrong_abi(void) {
     eq_control_t ctrl;
     eq_control_init_defaults(&ctrl);
@@ -82,6 +89,18 @@ static void test_validation_accepts_1_11_control_files(void) {
     eq_control_init_defaults(&ctrl);
 
     ctrl.version = EQ_LEGACY_ABI_VERSION_1_11;
+    ctrl.route_hint = EQ_ROUTE_SPEAKER;
+
+    ASSERT_TRUE(eq_control_validate(&ctrl) == 0);
+    ASSERT_EQ_U32(ctrl.version, EQ_ABI_VERSION);
+    ASSERT_EQ_U32(ctrl.route_hint, EQ_ROUTE_UNKNOWN);
+}
+
+static void test_validation_accepts_1_13_control_files(void) {
+    eq_control_t ctrl;
+    eq_control_init_defaults(&ctrl);
+
+    ctrl.version = EQ_LEGACY_ABI_VERSION_1_13;
     ctrl.route_hint = EQ_ROUTE_SPEAKER;
 
     ASSERT_TRUE(eq_control_validate(&ctrl) == 0);
@@ -473,9 +492,11 @@ static void test_boot_state_assumes_speaker_when_enabled_route_unknown(void) {
 
 int main(void) {
     test_defaults_are_compatible_and_safe();
+    test_current_branch_uses_1_14_abi();
     test_validation_rejects_wrong_abi();
     test_validation_accepts_legacy_size_and_normalizes();
     test_validation_accepts_1_11_control_files();
+    test_validation_accepts_1_13_control_files();
     test_validation_normalizes_and_clamps();
     test_headroom_mode_is_encoded_without_changing_control_size();
     test_legacy_payload_resets_headroom_mode();

--- a/tests/test_plugin_source.c
+++ b/tests/test_plugin_source.c
@@ -120,7 +120,7 @@ static void test_output_hook_drains_completed_before_processing_check(void)
     ASSERT_TRUE(audio_lock_branch != NULL);
     ASSERT_TRUE(audio_lock_branch < hook_end);
 
-    find_call = strstr(audio_lock_branch, "eq_audio_port_registry_find(&g_ports, port)");
+    find_call = strstr(audio_lock_branch, "eq_audio_port_registry_find_owned(&g_ports, owner_id, port)");
     ASSERT_TRUE(find_call != NULL);
     ASSERT_TRUE(find_call < hook_end);
 
@@ -259,9 +259,49 @@ static void test_unknown_port_recovery_reads_config_before_audio_lock(void)
     ASSERT_TRUE(lock_call < fn_end);
     ASSERT_TRUE(get_len < lock_call);
 
-    recover_call = strstr(lock_call, "eq_audio_port_registry_recover_config(&g_ports, port");
+    recover_call = strstr(lock_call, "eq_audio_port_registry_recover_config_owned(&g_ports, owner_id, port");
     ASSERT_TRUE(recover_call != NULL);
     ASSERT_TRUE(recover_call < fn_end);
+
+    free(source);
+}
+
+static void test_unknown_port_recovery_preserves_recovered_port_type_and_owner(void)
+{
+    char path[512];
+    char *source;
+    char *fn_start;
+    char *fn_end;
+
+    snprintf(path, sizeof(path), "%s/plugin/main.c", EQVITA_SOURCE_DIR);
+    source = read_file(path);
+
+    fn_start = strstr(source, "static int recover_port_config_after_output");
+    ASSERT_TRUE(fn_start != NULL);
+    fn_end = strstr(fn_start + 1, "static int sceAudioOutGetConfig_hook");
+    ASSERT_TRUE(fn_end != NULL);
+
+    ASSERT_TRUE(range_contains(fn_start, fn_end, "uint32_t owner_id = current_audio_owner_id();"));
+    ASSERT_TRUE(range_contains(fn_start, fn_end, "eq_audio_port_registry_recover_config_owned(&g_ports, owner_id, port, eq_audio_port_type_for_recovered_id(port)"));
+
+    free(source);
+}
+
+static void test_audio_hooks_use_process_owner_for_port_registry(void)
+{
+    char path[512];
+    char *source;
+
+    snprintf(path, sizeof(path), "%s/plugin/main.c", EQVITA_SOURCE_DIR);
+    source = read_file(path);
+
+    ASSERT_TRUE(strstr(source, "static uint32_t current_audio_owner_id(void)") != NULL);
+    ASSERT_TRUE(strstr(source, "ksceKernelGetProcessId()") != NULL);
+    ASSERT_TRUE(strstr(source, "eq_audio_port_registry_find_owned(&g_ports, owner_id, port)") != NULL);
+    ASSERT_TRUE(strstr(source, "eq_audio_port_registry_begin_processing_owned(&g_ports, owner_id, port)") != NULL);
+    ASSERT_TRUE(strstr(source, "eq_audio_port_registry_open_owned(&g_ports, owner_id, port") != NULL);
+    ASSERT_TRUE(strstr(source, "eq_audio_port_registry_set_config_owned(&g_ports, owner_id, port") != NULL);
+    ASSERT_TRUE(strstr(source, "eq_audio_port_registry_release_owned(&g_ports, owner_id, port)") != NULL);
 
     free(source);
 }
@@ -602,7 +642,7 @@ static void test_output_retry_guard_uses_processing_generation_directly(void)
 
     ASSERT_TRUE(!range_contains(error_guard, complete_call, "ret < 0 && (applied || retry_bypass)"));
     ASSERT_TRUE(range_contains(error_guard, complete_call, "eq_audio_tracked_port_note_output_error(processing_port, buf)"));
-    ASSERT_TRUE(!range_contains(error_guard, complete_call, "eq_audio_port_registry_find(&g_ports, port)"));
+    ASSERT_TRUE(!range_contains(error_guard, complete_call, "eq_audio_port_registry_find_owned(&g_ports, owner_id, port)"));
 
     free(source);
 }
@@ -1532,6 +1572,8 @@ int main(void)
     test_output_hook_recovers_when_returned_frames_disagree_with_tracked_config();
     test_output_hook_does_not_query_live_len_before_copying_audio();
     test_unknown_port_recovery_reads_config_before_audio_lock();
+    test_unknown_port_recovery_preserves_recovered_port_type_and_owner();
+    test_audio_hooks_use_process_owner_for_port_registry();
     test_unknown_port_recovery_rejects_negative_ports_before_get_config();
     test_output_hook_does_not_take_state_mutex_before_original_output();
     test_output_hook_updates_status_after_original_output();

--- a/tests/test_port_registry.c
+++ b/tests/test_port_registry.c
@@ -6,6 +6,9 @@
 
 static int failures;
 
+#define TEST_OWNER_A 0x1001u
+#define TEST_OWNER_B 0x2002u
+
 #define ASSERT_TRUE(expr) do { \
     if (!(expr)) { \
         printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
@@ -67,6 +70,87 @@ static void test_sparse_port_config_and_release_use_port_id_lookup(void) {
     ASSERT_TRUE(eq_audio_port_registry_release(&registry, 256) == 0);
     ASSERT_TRUE(eq_audio_port_registry_find(&registry, 256) == NULL);
     ASSERT_EQ_U32(eq_audio_port_registry_count(&registry), 0);
+}
+
+static void test_same_port_id_can_be_tracked_for_different_owners(void) {
+    eq_audio_port_registry_t registry;
+    eq_audio_tracked_port_t *first;
+    eq_audio_tracked_port_t *second;
+
+    eq_audio_port_registry_init(&registry);
+
+    first = eq_audio_port_registry_open_owned(&registry, TEST_OWNER_A, 7, EQ_AUDIO_PORT_TYPE_MAIN, 256, 48000, EQ_AUDIO_MODE_STEREO);
+    second = eq_audio_port_registry_open_owned(&registry, TEST_OWNER_B, 7, EQ_AUDIO_PORT_TYPE_MAIN, 512, 48000, EQ_AUDIO_MODE_STEREO);
+
+    ASSERT_TRUE(first != NULL);
+    ASSERT_TRUE(second != NULL);
+    ASSERT_TRUE(first != second);
+    ASSERT_EQ_U32(first->owner_id, TEST_OWNER_A);
+    ASSERT_EQ_U32(second->owner_id, TEST_OWNER_B);
+    ASSERT_EQ_U32(first->config.len, 256);
+    ASSERT_EQ_U32(second->config.len, 512);
+    ASSERT_TRUE(eq_audio_port_registry_find_owned(&registry, TEST_OWNER_A, 7) == first);
+    ASSERT_TRUE(eq_audio_port_registry_find_owned(&registry, TEST_OWNER_B, 7) == second);
+    ASSERT_EQ_U32(eq_audio_port_registry_count(&registry), 2);
+}
+
+static void test_releasing_one_owner_keeps_same_port_for_other_owner(void) {
+    eq_audio_port_registry_t registry;
+    eq_audio_tracked_port_t *first;
+    eq_audio_tracked_port_t *second;
+
+    eq_audio_port_registry_init(&registry);
+
+    first = eq_audio_port_registry_open_owned(&registry, TEST_OWNER_A, 7, EQ_AUDIO_PORT_TYPE_MAIN, 256, 48000, EQ_AUDIO_MODE_STEREO);
+    second = eq_audio_port_registry_open_owned(&registry, TEST_OWNER_B, 7, EQ_AUDIO_PORT_TYPE_MAIN, 512, 48000, EQ_AUDIO_MODE_STEREO);
+    ASSERT_TRUE(first != NULL);
+    ASSERT_TRUE(second != NULL);
+
+    ASSERT_EQ_I32(eq_audio_port_registry_release_owned(&registry, TEST_OWNER_A, 7), 0);
+
+    ASSERT_TRUE(eq_audio_port_registry_find_owned(&registry, TEST_OWNER_A, 7) == NULL);
+    ASSERT_TRUE(eq_audio_port_registry_find_owned(&registry, TEST_OWNER_B, 7) == second);
+    ASSERT_EQ_U32(second->config.len, 512);
+    ASSERT_EQ_U32(eq_audio_port_registry_count(&registry), 1);
+}
+
+static void test_registry_tracks_bgm_after_all_main_ports_are_open(void) {
+    eq_audio_port_registry_t registry;
+    eq_audio_tracked_port_t *bgm;
+
+    eq_audio_port_registry_init(&registry);
+
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_TRUE(eq_audio_port_registry_open_owned(&registry, TEST_OWNER_A, i, EQ_AUDIO_PORT_TYPE_MAIN, 256, 48000, EQ_AUDIO_MODE_STEREO) != NULL);
+    }
+
+    bgm = eq_audio_port_registry_open_owned(&registry, TEST_OWNER_A, EQ_AUDIO_BGM_PORT_ID, EQ_AUDIO_PORT_TYPE_BGM, 2048, 48000, EQ_AUDIO_MODE_STEREO);
+
+    ASSERT_TRUE(bgm != NULL);
+    ASSERT_EQ_I32(bgm->port_id, EQ_AUDIO_BGM_PORT_ID);
+    ASSERT_EQ_U32(bgm->owner_id, TEST_OWNER_A);
+    ASSERT_EQ_U32(bgm->config.type, EQ_AUDIO_PORT_TYPE_BGM);
+    ASSERT_EQ_U32(eq_audio_port_registry_count(&registry), 9);
+}
+
+static void test_recovered_bgm_port_keeps_bgm_type(void) {
+    eq_audio_port_registry_t registry;
+    eq_audio_tracked_port_t *slot;
+
+    eq_audio_port_registry_init(&registry);
+
+    slot = eq_audio_port_registry_recover_config_owned(&registry,
+                                                       TEST_OWNER_A,
+                                                       EQ_AUDIO_BGM_PORT_ID,
+                                                       eq_audio_port_type_for_recovered_id(EQ_AUDIO_BGM_PORT_ID),
+                                                       2048,
+                                                       48000,
+                                                       EQ_AUDIO_MODE_STEREO);
+
+    ASSERT_TRUE(slot != NULL);
+    ASSERT_EQ_I32(slot->port_id, EQ_AUDIO_BGM_PORT_ID);
+    ASSERT_EQ_U32(slot->owner_id, TEST_OWNER_A);
+    ASSERT_EQ_U32(slot->config.type, EQ_AUDIO_PORT_TYPE_BGM);
 }
 
 static void test_begin_processing_allows_different_ports_but_rejects_same_port_reentry(void) {
@@ -576,6 +660,10 @@ static void test_retry_bypass_ignores_null_buffers(void) {
 int main(void) {
     test_sparse_port_id_is_tracked_without_using_id_as_array_index();
     test_sparse_port_config_and_release_use_port_id_lookup();
+    test_same_port_id_can_be_tracked_for_different_owners();
+    test_releasing_one_owner_keeps_same_port_for_other_owner();
+    test_registry_tracks_bgm_after_all_main_ports_are_open();
+    test_recovered_bgm_port_keeps_bgm_type();
     test_begin_processing_allows_different_ports_but_rejects_same_port_reentry();
     test_release_defers_reset_until_processing_finishes();
     test_release_pending_slot_is_not_reused_while_processing();


### PR DESCRIPTION
## Summary

- Fix audio port tracking so reused Vita port ids are separated per process owner.
- Keep recovered BGM ports typed as BGM.
- Bump the app/plugin ABI to 1.14.

## Testing

- [x] Host tests run.
- [x] Vita Release build run.
- [x] Release hygiene check run.
- [x] Real Vita hardware tested, if this touches audio, boot, plugin, suspend/resume, install, or output routing.

## Vita Test Notes

- Vita model: PS Vita 1000
- Firmware: 3.65 Enso
- Output used: Vita speakers
- Preset used: existing user preset
- Games/apps tested: issue reproduction flow for the audio crashes
- Known limits: no new missing-plugin handling is included in this release.

## Audio/Plugin Changes

- [x] Hot-path work was kept small.
- [x] No file I/O, heap allocation, or noisy logging was added to the audio hook.
- [x] App and plugin ABI stayed compatible, or the ABI version was updated.
- [x] `ur0:data/eqvita/app.log` was checked after testing.

## Release Notes

- Fixed audio port tracking crashes when games/apps reuse Vita port ids.
- Fixed recovered BGM port metadata.
- Bumped app/plugin ABI to 1.14.